### PR TITLE
requirements.txt - Fix sip version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ PyInstaller==3.5
 PySide2==5.13.1
 requests==2.18.4
 shiboken2==5.13.1
-sip==4.19.8
+sip==5.3.0
 urllib3==1.24.2


### PR DESCRIPTION
Fixes error during install:

ERROR: Could not find a version that satisfies the requirement sip==4.19.8 (from -r requirements.txt (line 12)) (from versions: 5.0.0, 5.0.1, 5.1.0, 5.1.1, 5.1.2, 5.2.0, 5.3.0)
ERROR: No matching distribution found for sip==4.19.8 (from -r requirements.txt (line 12))